### PR TITLE
Use importlib

### DIFF
--- a/mkdocs_simple_hooks/__init__.py
+++ b/mkdocs_simple_hooks/__init__.py
@@ -2,6 +2,7 @@ import mkdocs
 import os
 import sys
 from functools import partial
+import importlib
 
 try:
     ModuleNotFoundError
@@ -44,7 +45,7 @@ class SimpleHooksPlugin(mkdocs.plugins.BasePlugin):
 
         package_path, function = hook_path.split(":")
         try:
-            hook_module = __import__(package_path)
+            hook_module = importlib.import_module(package_path)
         except ModuleNotFoundError:
             warns.append("Cannot import module '{}'.".format(package_path))
             return

--- a/mkdocs_simple_hooks/__init__.py
+++ b/mkdocs_simple_hooks/__init__.py
@@ -49,9 +49,6 @@ class SimpleHooksPlugin(mkdocs.plugins.BasePlugin):
         except ModuleNotFoundError:
             warns.append("Cannot import module '{}'.".format(package_path))
             return
-        module_name = package_path.split(".")[-1]
-        if hasattr(hook_module, module_name) and hook_module.__name__ != module_name:
-            hook_module = getattr(hook_module, module_name)
         hook_function = getattr(hook_module, function, None)
         if not hook_function:
             warns.append(

--- a/tests.py
+++ b/tests.py
@@ -114,11 +114,37 @@ def test_valid_hook_package(tmpdir, monkeypatch):
     assert result.output == "from on_pre_build\nfrom on_post_build\n"
 
 
+def test_valid_hook_namespace_package(tmpdir, monkeypatch):
+    test_docs = tmpdir / "hooks_ns_pkg"
+    test_docs.mkdir()
+
+    with open(str(test_docs / "hooks.py"), "w") as f:
+        f.write(
+            "def on_pre_build(*args, **kwargs):\n"
+            '    print("from on_pre_build")\n'
+            "def on_post_build(*args, **kwargs):\n"
+            '    print("from on_post_build")\n'
+        )
+
+    runner = setup_mkdocs(
+        {
+            "on_pre_build": "hooks_ns_pkg.hooks:on_pre_build",
+            "on_post_build": "hooks_ns_pkg.hooks:on_post_build",
+        },
+        monkeypatch,
+        tmpdir,
+    )
+
+    result = runner.invoke(build_command)
+    assert result.exit_code == 0
+    assert result.output == "from on_pre_build\nfrom on_post_build\n"
+
+
 def test_valid_hook_subpackage(tmpdir, monkeypatch):
-    test_package = tmpdir / "hooks_pkg"
+    test_package = tmpdir / "hooks_top_pkg"
     test_package.mkdir()
     open(str(test_package / "__init__.py"), "w").close()
-    test_docs = test_package / "hooks_subpkg"
+    test_docs = test_package / "hooks_sub_pkg"
     test_docs.mkdir()
     open(str(test_docs / "__init__.py"), "w").close()
 
@@ -132,8 +158,8 @@ def test_valid_hook_subpackage(tmpdir, monkeypatch):
 
     runner = setup_mkdocs(
         {
-            "on_pre_build": "hooks_pkg.hooks_subpkg.hooks:on_pre_build",
-            "on_post_build": "hooks_pkg.hooks_subpkg.hooks:on_post_build",
+            "on_pre_build": "hooks_top_pkg.hooks_sub_pkg.hooks:on_pre_build",
+            "on_post_build": "hooks_top_pkg.hooks_sub_pkg.hooks:on_post_build",
         },
         monkeypatch,
         tmpdir,

--- a/tests.py
+++ b/tests.py
@@ -87,7 +87,7 @@ def test_no_function(tmpdir, monkeypatch):
     assert "'no_function.hooks:on_pre_build' is not callable." in result.output
 
 
-def test_valid_hook(tmpdir, monkeypatch):
+def test_valid_hook_package(tmpdir, monkeypatch):
     test_docs = tmpdir / "valid_hook"
     test_docs.mkdir()
 
@@ -113,7 +113,7 @@ def test_valid_hook(tmpdir, monkeypatch):
     assert result.output == "from on_pre_build\nfrom on_post_build\n"
 
 
-def test_valid_hook_simple_module(tmpdir, monkeypatch):
+def test_valid_hook_module(tmpdir, monkeypatch):
     with open(str(tmpdir / "hooks.py"), "w") as f:
         f.write(
             "def on_pre_build(*args, **kwargs):\n"

--- a/tests.py
+++ b/tests.py
@@ -88,7 +88,7 @@ def test_no_function(tmpdir, monkeypatch):
 
 
 def test_valid_hook_package(tmpdir, monkeypatch):
-    test_docs = tmpdir / "valid_hook"
+    test_docs = tmpdir / "hooks_pkg"
     test_docs.mkdir()
 
     with open(str(test_docs / "hooks.py"), "w") as f:
@@ -101,8 +101,36 @@ def test_valid_hook_package(tmpdir, monkeypatch):
 
     runner = setup_mkdocs(
         {
-            "on_pre_build": "valid_hook.hooks:on_pre_build",
-            "on_post_build": "valid_hook.hooks:on_post_build",
+            "on_pre_build": "hooks_pkg.hooks:on_pre_build",
+            "on_post_build": "hooks_pkg.hooks:on_post_build",
+        },
+        monkeypatch,
+        tmpdir,
+    )
+
+    result = runner.invoke(build_command)
+    assert result.exit_code == 0
+    assert result.output == "from on_pre_build\nfrom on_post_build\n"
+
+
+def test_valid_hook_subpackage(tmpdir, monkeypatch):
+    test_package = tmpdir / "hooks_pkg"
+    test_package.mkdir()
+    test_docs = test_package / "hooks_subpkg"
+    test_docs.mkdir()
+
+    with open(str(test_docs / "hooks.py"), "w") as f:
+        f.write(
+            "def on_pre_build(*args, **kwargs):\n"
+            '    print("from on_pre_build")\n'
+            "def on_post_build(*args, **kwargs):\n"
+            '    print("from on_post_build")\n'
+        )
+
+    runner = setup_mkdocs(
+        {
+            "on_pre_build": "hooks_pkg.hooks_subpkg.hooks:on_pre_build",
+            "on_post_build": "hooks_pkg.hooks_subpkg.hooks:on_post_build",
         },
         monkeypatch,
         tmpdir,

--- a/tests.py
+++ b/tests.py
@@ -90,6 +90,7 @@ def test_no_function(tmpdir, monkeypatch):
 def test_valid_hook_package(tmpdir, monkeypatch):
     test_docs = tmpdir / "hooks_pkg"
     test_docs.mkdir()
+    open(str(test_docs / "__init__.py"), "w").close()
 
     with open(str(test_docs / "hooks.py"), "w") as f:
         f.write(
@@ -116,8 +117,10 @@ def test_valid_hook_package(tmpdir, monkeypatch):
 def test_valid_hook_subpackage(tmpdir, monkeypatch):
     test_package = tmpdir / "hooks_pkg"
     test_package.mkdir()
+    open(str(test_package / "__init__.py"), "w").close()
     test_docs = test_package / "hooks_subpkg"
     test_docs.mkdir()
+    open(str(test_docs / "__init__.py"), "w").close()
 
     with open(str(test_docs / "hooks.py"), "w") as f:
         f.write(


### PR DESCRIPTION
This change should allow for correct importing of nested packages.

Importlib is available from Python 3.1. The docs about `import_module()` mention some changes in Python 3.3, but I'm not experienced enough to assess whether they're relevant in the context of this PR. Anyway, this change makes either Python 3.1 or Python 3.3 the minimum requirement for using this plugin. Given the [table here](https://endoflife.date/python), I don't think it should be a big issue, 3.3 is officially unsupported for 3+ years already.

Closes https://github.com/aklajnert/mkdocs-simple-hooks/issues/4